### PR TITLE
docs: Add description to temporary .github/ISSUE_TEMPLATE files

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,10 @@
+## This configuration file overrides the inherited configuration file defined
+## in openedx/.github/.github/ISSUE_TEMPLATE because this repo currently does
+## not have Issues turned on, so we create this override to *only* show DEPR
+## issues to users creating Issues. Once Issues are turned on and the repo is
+## ready to accept Issues of all types, this file must be deleted so inheritance
+## of standard openedx configuration works properly.
+
 blank_issues_enabled: false
 contact_links:
   - name: Open edX Community Support

--- a/.github/ISSUE_TEMPLATE/depr-ticket.yml
+++ b/.github/ISSUE_TEMPLATE/depr-ticket.yml
@@ -1,3 +1,10 @@
+## This configuration file overrides the inherited configuration file defined
+## in openedx/.github/.github/ISSUE_TEMPLATE because this repo currently does
+## not have Issues turned on, so we create this override to *only* show DEPR
+## issues to users creating Issues. Once Issues are turned on and the repo is
+## ready to accept Issues of all types, this file must be deleted so inheritance
+## of standard openedx configuration works properly.
+
 name: Deprecation (DEPR) Ticket
 description: Per OEP-21, use this template to begin the technology deprecation process.
 title: "[DEPR]: <Technology Name>"


### PR DESCRIPTION
@feanil you mentioned in PR review that you'd like to see comments on these files so that future engineers will understand that the files ought to be temporary. Could you take a look here and provide review?